### PR TITLE
Add routing security-semantics audit for controller-backed routes

### DIFF
--- a/docs/security-semantics-in-routing-audit.md
+++ b/docs/security-semantics-in-routing-audit.md
@@ -1,0 +1,102 @@
+# Security Semantics in Routing Audit (Controllers)
+
+## Scope
+- Reviewed controller-backed routes across `routes/*.php` and routing bootstrap in `RouteServiceProvider`.
+- Focused on routing-level security semantics:
+  1. Missing/weak authentication/authorization middleware on sensitive routes.
+  2. State-changing operations exposed via `GET` (unsafe method semantics, CSRF-prone).
+
+## 1) Controllers needing stronger route middleware semantics
+
+### Critical: missing auth on impersonation stop
+- **Controller:** `Auth\ImpersonateController`
+- **Route:** `GET /teacher/impersonate/stop` (`stopImpersonate`)
+- **Issue:** Route has no explicit middleware while sibling impersonation routes require `auth` + role middleware.
+- **Needed semantics:** add `auth` and appropriate role guard middleware (at minimum parity with other impersonation routes).
+
+### Public operational endpoint
+- **Controller:** `TestController`
+- **Route:** `GET /checksms` (`checksms`)
+- **Issue:** test/operational action is publicly reachable.
+- **Needed semantics:** lock to admin/superadmin or remove in production.
+
+## 2) Controllers needing HTTP method hardening in routing (state change via GET)
+
+> These routes are generally inside authenticated groups, but still need security semantics hardening: destructive or mutating operations should not be `GET`.
+
+### Admin / back-office controllers
+- `AdmissionController@destroy`
+- `AcademicYearController@destroy`
+- `HolidaysController@destroy`
+- `StandardsLinkController@destroy`
+- `NotesController@delete`
+- `DisciplineController@destroy`
+- `TelephoneDirectoryController@destroy`
+- `UserController@resetPassword`
+- `DocumentsController@destroy`
+- `SubjectController@destroy`
+- `EventsController@destroy`
+- `HomeWorkController@destroy`
+- `Approval\HomeWorkController@destroy`
+- `NoticeBoardController@destroy`
+- `LeaveTypesController@destroy`
+- `BulletinsController@destroy`
+- `TaskController@destroy`
+- `VisitorLogController@destroy`
+- `CallLogController@destroy`
+- `PostalRecordController@destroy`
+- `PagesController@destroy`
+- `PostsController@destroy`
+- `PostCommentsController@destroy`
+- `PostReplyCommentsController@destroy`
+
+### Teacher / student / librarian / receptionist controllers
+- `Teacher\AssignmentController@destroy`
+- `Teacher\LeaveController@destroy`
+- `Teacher\TaskController@destroy`
+- `Teacher\LessonPlanController@destroy`
+- `Teacher\HomeWorkController@destroy`
+- `Teacher\VisitorLogController@destroy`
+- `Teacher\CallLogController@destroy`
+- `Teacher\PostalRecordController@destroy`
+- `Teacher\PostsController@destroy`
+- `Teacher\PostCommentsController@destroy`
+- `Teacher\PostReplyCommentsController@destroy`
+- `Student\TaskController@destroy`
+- `Student\AssignmentController@destroy`
+- `Student\HomeworkController@destroy`
+- `Student\PostCommentsController@destroy`
+- `Student\PostReplyCommentsController@destroy`
+- `Librarian\BookCategoryController@destroy`
+- `Librarian\BookController@destroy`
+- `Librarian\BookLendingController@destroy`
+- `Librarian\TaskController@destroy`
+- `Receptionist\VisitorLogController@destroy`
+- `Receptionist\CallLogController@destroy`
+- `Receptionist\PostalRecordController@destroy`
+- `Receptionist\TaskController@destroy`
+- `Receptionist\TelephoneDirectoryController@destroy`
+- `Receptionist\LeaveController@destroy`
+- `Accountant\TaskController@destroy`
+
+### API controllers (including teacher API)
+- `Api\LeaveController@destroy`
+- `Api\HomeworkController@destroy`
+- `Api\AssignmentController@destroy`
+- `Api\TaskController@destroy`
+- `Api\Teacher\Approval\AssignmentController@destroy`
+- `Api\Teacher\Approval\HomeworkController@destroy`
+- `Api\Teacher\LeaveController@destroy`
+- `Api\Teacher\TaskController@destroy`
+- `Api\Teacher\DisciplineController@destroy`
+
+## Recommended route-level fixes (doc checklist)
+1. **Replace `GET` mutators** with `DELETE`/`POST`/`PATCH` as appropriate.
+2. Add explicit `->middleware([...])` on sensitive standalone routes in `web.php`.
+3. For API mutators, enforce both auth middleware and ability/policy middleware.
+4. Add throttling for auth-adjacent/public endpoints (`login`, password reset, OTP, verification).
+5. Ensure frontend calls use CSRF-protected non-GET requests for all destructive actions.
+
+## Notes
+- Role route files are mostly protected globally in `RouteServiceProvider` (e.g., admin/teacher/student route groups), but HTTP verb semantics still require hardening.
+- This is a routing-semantics audit; controller-internal authorization (`Gate`/policy checks) should be reviewed separately.


### PR DESCRIPTION
### Motivation
- Audit routing-level security semantics to find routes that lack proper middleware or expose mutating/destructive operations via `GET` which can cause CSRF and authorization gaps.
- Provide a concise, actionable list so maintainers can harden route-level protections before making code changes.

### Description
- Added `docs/security-semantics-in-routing-audit.md` containing an audit of controller-backed routes, listing controllers/routes that need stronger middleware or HTTP-verb hardening.
- The document enumerates admin/back-office, role-specific (teacher/student/librarian/receptionist/accountant) and API controllers that expose mutators via `GET` or appear publicly reachable without explicit auth.
- Included a remediation checklist recommending verb changes (`DELETE`/`POST`/`PATCH`), explicit middleware on standalone routes, API ability/policy enforcement, and throttling for auth-adjacent endpoints.
- Noted that `RouteServiceProvider` applies many role-based group protections, but HTTP-verb semantics still require review.

### Testing
- Ran route-scanning automation (`rg` and Python scripts) to enumerate controller routes and detect `GET` mutators, which completed successfully and produced the lists in the audit.
- Verified the new file exists with `test -f docs/security-semantics-in-routing-audit.md` which returned `OK`.
- Executed targeted `rg` queries (e.g., searching for `stopImpersonate`, `/checksms`, and `Controller@(destroy|delete|resetPassword)`) and confirmed matches were found in `routes/*.php` as reflected in the audit.
- Attempted `php artisan route:list` to produce a framework route listing but it failed due to a missing `vendor/autoload.php`, so a full artisan route dump could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4d46b4df0832b9470b75342ae715e)